### PR TITLE
Added Ability to Add Words to THES_DICT from File in roget/ Directory

### DIFF
--- a/roget.py
+++ b/roget.py
@@ -25,6 +25,26 @@ class Roget:
             self.full_childparent = cPickle.load(f)
         with open('roget/num_cat.txt','r') as f:
             self.num_cat = cPickle.load(f)
+            
+    def add_custom_words(self,fid='roget/add_words.txt'):
+    ''' Load a file of words and connections into THES_DICT '''
+        try:
+            type(self.added_words) is list
+        except:
+            self.added_words = []
+        with open(fid,'rb') as f:
+            for line in f:
+                wd_pair = line.strip().split(',')
+                if wd_pair[0] not in self.thes_dict:
+                    self.thes_dict[wd_pair[0]] = [wd_pair[1],]
+                    self.added_words.append(wd_pair[0])
+                else:
+                    if wd_pair[1] not in self.thes_dict[wd_pair[0]]:
+                        self.thes_dict[wd_pair[0]].append(wd_pair[1])
+
+        self.added_words = list(set(self.added_words))
+        print "Words Added to THES_DICT:"
+        print ' '.join(self.added_words)
 
     def make_wordlist(self,myText,lower=True):
         '''Removes punctuation and returns list of words; 'lower' flag determines case'''

--- a/roget/add_words.txt
+++ b/roget/add_words.txt
@@ -1,0 +1,3 @@
+jacket,cat0225
+jacket,cat0204
+jacket,cat0223


### PR DESCRIPTION
Some common words are not in the thesaurus, but should be linked to the same categories as it's synonyms that are in the thesaurus.  One example is <i>jacket</i> which is not in, but should share the categories that <b>coat</b> has (although Category=LAYER is debatable).

The added module makes use of a supplemental file that users can maintain to add custom relationships, whether they be needed due to common word usage or custom word usage in the event of proper nouns and other such special cases.
